### PR TITLE
Made erroring safer with try catch

### DIFF
--- a/node-cobinhood-api.js
+++ b/node-cobinhood-api.js
@@ -76,13 +76,15 @@ module.exports = function() {
 	};
 
 	const safeError = function (response) {
+		let errorMsg;
 		try {
-			const errorCode = JSON.parse(response.body).error.error_code;
+			errorMsg = JSON.parse(response.body).error.error_code;
 		} catch (err) {
-			console.log('Error:', err)
-			return err;
+			console.log('Cobinhood connection error:', err)
+			errorMsg = 'JSON response from Cobinhood is malformed';
+		} finally {
+			return errorMsg;
 		}
-		return error;
 	}
 
 	return {

--- a/node-cobinhood-api.js
+++ b/node-cobinhood-api.js
@@ -75,6 +75,16 @@ module.exports = function() {
 		}
 	};
 
+	const safeError = function (response) {
+		try {
+			const errorCode = JSON.parse(response.body).error.error_code;
+		} catch (err) {
+			console.log('Error:', err)
+			return err;
+		}
+		return error;
+	}
+
 	return {
 		options: function(opts) {
 			for (let opt in opts) {
@@ -90,7 +100,7 @@ module.exports = function() {
 					return callback(error);
 
 				if (response && response.statusCode !== 200)
-					return callback(JSON.parse(response.body).error.error_code);
+					return callback(safeError(response));
 
 				let result = JSON.parse(body).result.time;
 				return callback(false, result);
@@ -105,7 +115,7 @@ module.exports = function() {
 					return callback(error);
 
 				if (response && response.statusCode !== 200)
-					return callback(JSON.parse(response.body).error.error_code);
+					return callback(safeError(response));
 
 				let result = JSON.parse(body).result.info;
 				return callback(false, result);
@@ -120,7 +130,7 @@ module.exports = function() {
 					return callback(error);
 
 				if (response && response.statusCode !== 200)
-					return callback(JSON.parse(response.body).error.error_code);
+					return callback(safeError(response));
 
 				let result = JSON.parse(body).result.currencies;
 				return callback(false, result);
@@ -135,7 +145,7 @@ module.exports = function() {
 					return callback(error);
 
 				if (response && response.statusCode !== 200)
-					return callback(JSON.parse(response.body).error.error_code);
+					return callback(safeError(response));
 
 				let result = JSON.parse(body).result.trading_pairs;
 				return callback(false, result);
@@ -151,7 +161,7 @@ module.exports = function() {
 					return callback(error);
 
 				if (response && response.statusCode !== 200)
-					return callback(JSON.parse(response.body).error.error_code);
+					return callback(safeError(response));
 
 				let orderbook = JSON.parse(body).result.orderbook;
 				let result = {
@@ -188,7 +198,7 @@ module.exports = function() {
 					return callback(error);
 
 				if (response && response.statusCode !== 200)
-					return callback(JSON.parse(response.body).error.error_code);
+					return callback(safeError(response));
 
 				let result = JSON.parse(body).result;
 				return callback(false, result);
@@ -203,7 +213,7 @@ module.exports = function() {
 					return callback(error);
 
 				if (response && response.statusCode !== 200)
-					return callback(JSON.parse(response.body).error.error_code);
+					return callback(safeError(response));
 
 				let result = JSON.parse(body).result.ticker;
 				return callback(false, result);
@@ -218,7 +228,7 @@ module.exports = function() {
 					return callback(error);
 
 				if (response && response.statusCode !== 200)
-					return callback(JSON.parse(response.body).error.error_code);
+					return callback(safeError(response));
 
 				let result = JSON.parse(body).result.tickers;
 				return callback(false, result);
@@ -233,7 +243,7 @@ module.exports = function() {
 					return callback(error);
 
 				if (response && response.statusCode !== 200)
-					return callback(JSON.parse(response.body).error.error_code);
+					return callback(safeError(response));
 
 				let result = JSON.parse(body).result.ticker.last_trade_price;
 				return callback(false, result);
@@ -249,7 +259,7 @@ module.exports = function() {
 					return callback(error);
 
 				if (response && response.statusCode !== 200)
-					return callback(JSON.parse(response.body).error.error_code);
+					return callback(safeError(response));
 
 				let result = JSON.parse(body).result.trades;
 				return callback(false, result);
@@ -268,7 +278,7 @@ module.exports = function() {
 					return callback(error);
 
 				if (response && response.statusCode !== 200)
-					return callback(JSON.parse(response.body).error.error_code);
+					return callback(safeError(response));
 
 				let result = JSON.parse(body).result.candles;
 				return callback(false, result);
@@ -284,7 +294,7 @@ module.exports = function() {
 					return callback(error);
 
 				if (response && response.statusCode !== 200)
-					return callback(JSON.parse(response.body).error.error_code);
+					return callback(safeError(response));
 
 				let result = JSON.parse(body).result.order;
 				return callback(false, result);
@@ -300,7 +310,7 @@ module.exports = function() {
 					return callback(error);
 
 				if (response && response.statusCode !== 200)
-					return callback(JSON.parse(response.body).error.error_code);
+					return callback(safeError(response));
 
 				let result = JSON.parse(body).result.trades;
 				return callback(false, result);
@@ -318,7 +328,7 @@ module.exports = function() {
 					return callback(error);
 
 				if (response && response.statusCode !== 200)
-					return callback(JSON.parse(response.body).error.error_code);
+					return callback(safeError(response));
 
 				let result = JSON.parse(body).result.orders;
 				return callback(false, result);
@@ -335,7 +345,7 @@ module.exports = function() {
 					return callback(error);
 
 				if (response && response.statusCode !== 200)
-					return callback(JSON.parse(response.body).error.error_code);
+					return callback(safeError(response));
 
 				let result = JSON.parse(body).result.orders;
 				return callback(false, result);
@@ -353,7 +363,7 @@ module.exports = function() {
 					return callback(error);
 
 				if (response && response.statusCode !== 200)
-					return callback(JSON.parse(response.body).error.error_code);
+					return callback(safeError(response));
 
 				let result = JSON.parse(body).success;
 				return callback(false, result);
@@ -375,7 +385,7 @@ module.exports = function() {
 					return callback(error);
 
 				if (response && response.statusCode !== 200)
-					return callback(JSON.parse(response.body).error.error_code);
+					return callback(safeError(response));
 
 				let result = body.success;
 				return callback(false, result);
@@ -393,7 +403,7 @@ module.exports = function() {
 					return callback(error);
 
 				if (response && response.statusCode !== 200)
-					return callback(JSON.parse(response.body).error.error_code);
+					return callback(safeError(response));
 
 				let result = JSON.parse(body).result.orders;
 				return callback(false, result);
@@ -410,7 +420,7 @@ module.exports = function() {
 					return callback(error);
 
 				if (response && response.statusCode !== 200)
-					return callback(JSON.parse(response.body).error.error_code);
+					return callback(safeError(response));
 
 				let result = JSON.parse(body).result.orders;
 				return callback(false, result);
@@ -436,9 +446,8 @@ module.exports = function() {
 			request(opt, function(error, response, body) {
 				if (error)
 					return callback(error);
-
 				if (response && response.statusCode !== 200)
-					return callback(JSON.parse(response.body).error.error_code);
+					return callback(safeError(response));
 
 				let result = JSON.parse(body).result.balances;
 				return callback(false, result);
@@ -456,7 +465,7 @@ module.exports = function() {
 					return callback(error);
 
 				if (response && response.statusCode !== 200)
-					return callback(JSON.parse(response.body).error.error_code);
+					return callback(safeError(response));
 
 				let result = JSON.parse(body).result.ledger;
 				return callback(false, result);
@@ -473,7 +482,7 @@ module.exports = function() {
 					return callback(error);
 
 				if (response && response.statusCode !== 200)
-					return callback(JSON.parse(response.body).error.error_code);
+					return callback(safeError(response));
 
 				let result = JSON.parse(body).result.ledger;
 				return callback(false, result);
@@ -490,7 +499,7 @@ module.exports = function() {
 					return callback(error);
 
 				if (response && response.statusCode !== 200)
-					return callback(JSON.parse(response.body).error.error_code);
+					return callback(safeError(response));
 
 				let result = JSON.parse(body).result.deposit_addresses;
 				return callback(false, result);
@@ -506,7 +515,7 @@ module.exports = function() {
 					return callback(error);
 
 				if (response && response.statusCode !== 200)
-					return callback(JSON.parse(response.body).error.error_code);
+					return callback(safeError(response));
 
 				let result = JSON.parse(body).result.deposit_addresses;
 				return callback(false, result);
@@ -522,7 +531,7 @@ module.exports = function() {
 					return callback(error);
 
 				if (response && response.statusCode !== 200)
-					return callback(JSON.parse(response.body).error.error_code);
+					return callback(safeError(response));
 
 				let result = JSON.parse(body).result.deposit;
 				return callback(false, result);
@@ -538,7 +547,7 @@ module.exports = function() {
 					return callback(error);
 
 				if (response && response.statusCode !== 200)
-					return callback(JSON.parse(response.body).error.error_code);
+					return callback(safeError(response));
 
 				let result = JSON.parse(body).result.deposits;
 				return callback(false, result);
@@ -555,7 +564,7 @@ module.exports = function() {
 					return callback(error);
 
 				if (response && response.statusCode !== 200)
-					return callback(JSON.parse(response.body).error.error_code);
+					return callback(safeError(response));
 
 				let result = JSON.parse(body).result.withdrawal_addresses;
 				return callback(false, result);
@@ -571,7 +580,7 @@ module.exports = function() {
 					return callback(error);
 
 				if (response && response.statusCode !== 200)
-					return callback(JSON.parse(response.body).error.error_code);
+					return callback(safeError(response));
 
 				let result = JSON.parse(body).result.withdrawal_addresses;
 				return callback(false, result);
@@ -587,7 +596,7 @@ module.exports = function() {
 					return callback(error);
 
 				if (response && response.statusCode !== 200)
-					return callback(JSON.parse(response.body).error.error_code);
+					return callback(safeError(response));
 
 				let result = JSON.parse(body).result.withdrawal;
 				return callback(false, result);
@@ -603,7 +612,7 @@ module.exports = function() {
 					return callback(error);
 
 				if (response && response.statusCode !== 200)
-					return callback(JSON.parse(response.body).error.error_code);
+					return callback(safeError(response));
 
 				let result = JSON.parse(body).result.withdrawals;
 				return callback(false, result);


### PR DESCRIPTION
During the current cobinhood outage, the server was returning html and the JSON parser was erring out. So using a try catch is much safer for us.